### PR TITLE
feat(program): wire place_order into program module

### DIFF
--- a/program/src/instructions/mod.rs
+++ b/program/src/instructions/mod.rs
@@ -9,6 +9,7 @@
 //! - [`create_open_orders`] - Creates a user's trading account for a market
 //! - [`deposit`] - Deposits tokens into a user's OpenOrders account
 //! - [`withdraw`] - Withdraws tokens from a user's OpenOrders account
+//! - [`place_order`] - Places a new order on the order book
 //! - [`cancel_order`] - Cancels an order from the order book
 //! - [`cancel_all_orders`] - Cancels all orders for a user
 //! - [`match_orders`] - Executes the matching algorithm (crank)
@@ -21,6 +22,7 @@ pub mod create_market;
 pub mod create_open_orders;
 pub mod deposit;
 pub mod match_orders;
+pub mod place_order;
 pub mod withdraw;
 
 pub use cancel_all_orders::CancelAllOrdersParams;
@@ -33,4 +35,5 @@ pub use create_market::{
 pub use create_open_orders::CreateOpenOrdersParams;
 pub use deposit::DepositParams;
 pub use match_orders::MatchOrdersParams;
+pub use place_order::{OrderType, PlaceOrderParams};
 pub use withdraw::WithdrawParams;

--- a/program/src/instructions/place_order.rs
+++ b/program/src/instructions/place_order.rs
@@ -30,13 +30,13 @@ use crate::state::{LeafNode, OrderId, Side, TimeInForce, SENTINEL};
 pub enum OrderType {
     /// Rests on book if not immediately fillable.
     #[default]
-    Limit = 0,
+    Limit,
     /// Fills what it can immediately, cancels the rest.
-    ImmediateOrCancel = 1,
+    ImmediateOrCancel,
     /// Only accepted if it would rest on book (no immediate fill).
-    PostOnly = 2,
+    PostOnly,
     /// Fills completely or cancels entirely.
-    FillOrKill = 3,
+    FillOrKill,
 }
 
 impl From<u8> for OrderType {

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -26,9 +26,9 @@ pub mod state;
 pub use error::{ErrorCategory, MatchbookError};
 pub use instructions::{
     CancelAllOrdersParams, CancelOrderParams, ConsumeEventsParams, CreateMarketParams,
-    CreateOpenOrdersParams, DepositParams, MatchOrdersParams, WithdrawParams, BASE_VAULT_SEED,
-    EVENT_QUEUE_ACCOUNT_SIZE, MAX_FEE_BPS, MAX_MAKER_FEE_BPS, MAX_MAKER_REBATE_BPS,
-    ORDERBOOK_ACCOUNT_SIZE, QUOTE_VAULT_SEED,
+    CreateOpenOrdersParams, DepositParams, MatchOrdersParams, OrderType, PlaceOrderParams,
+    WithdrawParams, BASE_VAULT_SEED, EVENT_QUEUE_ACCOUNT_SIZE, MAX_FEE_BPS, MAX_MAKER_FEE_BPS,
+    MAX_MAKER_REBATE_BPS, ORDERBOOK_ACCOUNT_SIZE, QUOTE_VAULT_SEED,
 };
 
 pub use state::{
@@ -126,6 +126,30 @@ pub mod matchbook {
     /// - Insufficient free balance
     pub fn withdraw(ctx: Context<Withdraw>, params: WithdrawParams) -> Result<()> {
         instructions::withdraw::handler(ctx, params)
+    }
+
+    /// Places a new order on the order book.
+    ///
+    /// Validates parameters, locks the required funds in the user's
+    /// OpenOrders account, and inserts the order into the appropriate
+    /// book side. Both owner and delegate can place orders.
+    ///
+    /// # Arguments
+    ///
+    /// * `ctx` - The instruction context
+    /// * `params` - Order parameters (side, price, quantity, type, client_order_id)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - Market is not active
+    /// - Authority is not authorized
+    /// - Price or quantity is invalid
+    /// - Insufficient free balance
+    /// - No free order slot available
+    /// - PostOnly order would cross the spread
+    pub fn place_order(ctx: Context<PlaceOrder>, params: PlaceOrderParams) -> Result<()> {
+        instructions::place_order::handler(ctx, params)
     }
 
     /// Cancels an order from the order book.
@@ -456,6 +480,41 @@ pub struct Withdraw<'info> {
 
     /// SPL Token program.
     pub token_program: Program<'info, Token>,
+}
+
+/// Accounts for the PlaceOrder instruction.
+#[derive(Accounts)]
+#[instruction(params: PlaceOrderParams)]
+pub struct PlaceOrder<'info> {
+    /// Authority placing the order (owner or delegate).
+    pub authority: Signer<'info>,
+
+    /// Market to place the order on. Mutable to advance the order sequence number.
+    #[account(
+        mut,
+        has_one = bids @ MatchbookError::InvalidAccountData,
+        has_one = asks @ MatchbookError::InvalidAccountData
+    )]
+    pub market: Account<'info, Market>,
+
+    /// User's OpenOrders account.
+    #[account(
+        mut,
+        seeds = [OPEN_ORDERS_SEED, market.key().as_ref(), open_orders.owner.as_ref()],
+        bump = open_orders.bump,
+        constraint = open_orders.is_authorized(authority.key) @ MatchbookError::Unauthorized
+    )]
+    pub open_orders: Account<'info, OpenOrders>,
+
+    /// Bids order book account.
+    /// CHECK: Validated via has_one on market.
+    #[account(mut)]
+    pub bids: UncheckedAccount<'info>,
+
+    /// Asks order book account.
+    /// CHECK: Validated via has_one on market.
+    #[account(mut)]
+    pub asks: UncheckedAccount<'info>,
 }
 
 /// Accounts for the CancelOrder instruction.


### PR DESCRIPTION
## Summary

`place_order.rs` existed with a full handler and `PlaceOrderParams`, but the module was never declared in `instructions/mod.rs`, so it never compiled and the instruction was not exposed. The handler referenced `crate::PlaceOrder`, which did not exist — the `cannot find type PlaceOrder in the crate root` error from the issue.

- Declare `place_order` module and re-export `OrderType`, `PlaceOrderParams`
- Add `place_order` entry to the `#[program]` module, delegating to the existing handler
- Add `PlaceOrder` accounts struct: `authority` (Signer, owner or delegate), `market` (mut — handler advances the order sequence number, `has_one` bids/asks), `open_orders` (mut, PDA seeds + `is_authorized` constraint, same pattern as `CancelOrder`), `bids`/`asks` (mut, validated via `has_one`)
- Drop explicit discriminants on `OrderType` (`Limit = 0`, …): borsh rejects explicit discriminants without a `use_discriminant` attribute; implicit values are identical (0–3), same wire format, consistent with the `Side` enum

Closes #123

## Test plan

- `cargo build --workspace` passes
- `cargo test -p matchbook-program`: 140 tests pass (119 unit + 21 integration), including the 10 `place_order` unit tests that previously never compiled
- `cargo clippy -p matchbook-program --all-targets`: no new warnings (the two `diverging_sub_expression` warnings on `#[program]` are pre-existing, verified against a clean tree)

## Out of scope (follow-ups worth tracking)

- The SDK `PlaceOrderBuilder` diverges from the on-chain instruction: extra fields (`self_trade_behavior`, `expiry_slot`), a placeholder discriminator instead of the Anchor sighash, and extra accounts. It will not work against the program until aligned.
- `get_best_price` always returns `None` (existing TODO), so the PostOnly crossing check is currently inert.