### PR TITLE
build(ts-sdk): migrate off node10 module resolution for TS7 readiness

### DIFF
--- a/ts-sdk/package-lock.json
+++ b/ts-sdk/package-lock.json
@@ -275,9 +275,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.138.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
-      "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -285,9 +285,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
-      "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
       "cpu": [
         "arm64"
       ],
@@ -302,9 +302,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
-      "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
       "cpu": [
         "arm64"
       ],
@@ -319,9 +319,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
-      "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
       "cpu": [
         "x64"
       ],
@@ -336,9 +336,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
-      "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
       "cpu": [
         "x64"
       ],
@@ -353,9 +353,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
-      "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
       "cpu": [
         "arm"
       ],
@@ -370,9 +370,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
-      "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
       "cpu": [
         "arm64"
       ],
@@ -390,9 +390,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
-      "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
       "cpu": [
         "arm64"
       ],
@@ -410,9 +410,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
-      "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
       "cpu": [
         "ppc64"
       ],
@@ -430,9 +430,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
-      "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
       "cpu": [
         "s390x"
       ],
@@ -450,9 +450,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
-      "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
       "cpu": [
         "x64"
       ],
@@ -470,9 +470,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
-      "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
       "cpu": [
         "x64"
       ],
@@ -490,9 +490,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
-      "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
       "cpu": [
         "arm64"
       ],
@@ -507,9 +507,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
-      "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
       "cpu": [
         "wasm32"
       ],
@@ -526,9 +526,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
-      "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
       "cpu": [
         "arm64"
       ],
@@ -543,9 +543,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
-      "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
       "cpu": [
         "x64"
       ],
@@ -663,9 +663,9 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1117,9 +1117,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
-      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1847,9 +1847,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -1984,9 +1984,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
+      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
       "dev": true,
       "funding": [
         {
@@ -2033,13 +2033,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
-      "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.138.0",
+        "@oxc-project/types": "=0.139.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -2049,21 +2049,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.1.4",
-        "@rolldown/binding-darwin-arm64": "1.1.4",
-        "@rolldown/binding-darwin-x64": "1.1.4",
-        "@rolldown/binding-freebsd-x64": "1.1.4",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
-        "@rolldown/binding-linux-arm64-gnu": "1.1.4",
-        "@rolldown/binding-linux-arm64-musl": "1.1.4",
-        "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
-        "@rolldown/binding-linux-s390x-gnu": "1.1.4",
-        "@rolldown/binding-linux-x64-gnu": "1.1.4",
-        "@rolldown/binding-linux-x64-musl": "1.1.4",
-        "@rolldown/binding-openharmony-arm64": "1.1.4",
-        "@rolldown/binding-wasm32-wasi": "1.1.4",
-        "@rolldown/binding-win32-arm64-msvc": "1.1.4",
-        "@rolldown/binding-win32-x64-msvc": "1.1.4"
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
     "node_modules/semver": {
@@ -2267,16 +2267,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
-      "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
+        "picomatch": "^4.0.5",
         "postcss": "^8.5.16",
-        "rolldown": "~1.1.3",
+        "rolldown": "~1.1.4",
         "tinyglobby": "^0.2.17"
       },
       "bin": {

--- a/ts-sdk/package.json
+++ b/ts-sdk/package.json
@@ -8,9 +8,9 @@
   "types": "dist/types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "types": "./dist/types/index.d.ts"
+      "require": "./dist/cjs/index.js"
     }
   },
   "files": [
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "npm run build:esm && npm run build:cjs && npm run build:types",
     "build:esm": "tsc -p tsconfig.esm.json",
-    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:cjs": "tsc -p tsconfig.cjs.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
     "build:types": "tsc -p tsconfig.types.json",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/ts-sdk/src/api/index.ts
+++ b/ts-sdk/src/api/index.ts
@@ -20,7 +20,7 @@ export type {
   PlaceOrderResponse,
   CancelOrderResponse,
   BuildTransactionResponse,
-} from './rest';
+} from './rest.js';
 
 export type {
   WsChannel,
@@ -40,6 +40,6 @@ export type {
   WsErrorMessage,
   WsServerMessage,
   WsMessage,
-} from './websocket';
+} from './websocket.js';
 
-export { WS_CHANNELS } from './websocket';
+export { WS_CHANNELS } from './websocket.js';

--- a/ts-sdk/src/api/rest.ts
+++ b/ts-sdk/src/api/rest.ts
@@ -4,7 +4,7 @@
  * @module api/rest
  */
 
-import type { Market, Order, Trade, OrderBook, Balance, MarketSummary } from '../types';
+import type { Market, Order, Trade, OrderBook, Balance, MarketSummary } from '../types/index.js';
 
 /**
  * Generic API response wrapper.

--- a/ts-sdk/src/api/websocket.ts
+++ b/ts-sdk/src/api/websocket.ts
@@ -4,8 +4,8 @@
  * @module api/websocket
  */
 
-import type { Price, Quantity, Side, OrderStatus } from '../types';
-import type { BookLevel, BookChange } from '../types';
+import type { Price, Quantity, Side, OrderStatus } from '../types/index.js';
+import type { BookLevel, BookChange } from '../types/index.js';
 
 /**
  * WebSocket channel types.

--- a/ts-sdk/src/client/http.ts
+++ b/ts-sdk/src/client/http.ts
@@ -15,12 +15,12 @@ import type {
   CancelOrderParams,
   DepositParams,
   WithdrawParams,
-} from '../types';
+} from '../types/index.js';
 
-import type { BuildTransactionResponse } from '../api';
+import type { BuildTransactionResponse } from '../api/index.js';
 
-import type { ResolvedConfig } from './config';
-import { resolveConfig, validateConfig, type ClientConfig } from './config';
+import type { ResolvedConfig } from './config.js';
+import { resolveConfig, validateConfig, type ClientConfig } from './config.js';
 import {
   HttpError,
   ApiError,
@@ -28,7 +28,7 @@ import {
   RateLimitError,
   NotFoundError,
   UnauthorizedError,
-} from './errors';
+} from './errors.js';
 
 /**
  * HTTP client for the Matchbook REST API.

--- a/ts-sdk/src/client/index.ts
+++ b/ts-sdk/src/client/index.ts
@@ -27,14 +27,14 @@
  * ```
  */
 
-export type { ClientConfig, ResolvedConfig } from './config';
+export type { ClientConfig, ResolvedConfig } from './config.js';
 export {
   DEFAULT_BASE_URL,
   DEFAULT_WS_URL,
   DEFAULT_TIMEOUT,
   resolveConfig,
   validateConfig,
-} from './config';
+} from './config.js';
 
 export {
   ClientError,
@@ -49,9 +49,9 @@ export {
   isHttpError,
   isApiError,
   isRateLimitError,
-} from './errors';
+} from './errors.js';
 
-export { MatchbookClient } from './http';
+export { MatchbookClient } from './http.js';
 
-export type { BookCallback, TradeCallback, OrderCallback, ErrorCallback } from './websocket';
-export { MatchbookWsClient } from './websocket';
+export type { BookCallback, TradeCallback, OrderCallback, ErrorCallback } from './websocket.js';
+export { MatchbookWsClient } from './websocket.js';

--- a/ts-sdk/src/client/websocket.ts
+++ b/ts-sdk/src/client/websocket.ts
@@ -11,11 +11,11 @@ import type {
   WsBookUpdateMessage,
   WsTradeMessage,
   WsOrderUpdateMessage,
-} from '../api';
+} from '../api/index.js';
 
-import type { ResolvedConfig } from './config';
-import { resolveConfig, validateConfig, type ClientConfig } from './config';
-import { WebSocketError } from './errors';
+import type { ResolvedConfig } from './config.js';
+import { resolveConfig, validateConfig, type ClientConfig } from './config.js';
+import { WebSocketError } from './errors.js';
 
 /**
  * Subscription callback types.

--- a/ts-sdk/src/guards/index.ts
+++ b/ts-sdk/src/guards/index.ts
@@ -26,4 +26,4 @@ export {
   assertTrade,
   assertOrderBook,
   assertBalance,
-} from './validators';
+} from './validators.js';

--- a/ts-sdk/src/guards/validators.ts
+++ b/ts-sdk/src/guards/validators.ts
@@ -16,7 +16,7 @@ import type {
   BookLevel,
   OrderBook,
   Balance,
-} from '../types';
+} from '../types/index.js';
 
 import {
   SIDES,
@@ -24,7 +24,7 @@ import {
   TIME_IN_FORCE_VALUES,
   ORDER_STATUSES,
   SELF_TRADE_BEHAVIORS,
-} from '../types';
+} from '../types/index.js';
 
 /**
  * Checks if a value is a valid Side.

--- a/ts-sdk/src/index.ts
+++ b/ts-sdk/src/index.ts
@@ -31,7 +31,7 @@ export type {
   TimeInForce,
   OrderStatus,
   SelfTradeBehavior,
-} from './types';
+} from './types/index.js';
 
 export {
   SIDES,
@@ -39,7 +39,7 @@ export {
   TIME_IN_FORCE_VALUES,
   ORDER_STATUSES,
   SELF_TRADE_BEHAVIORS,
-} from './types';
+} from './types/index.js';
 
 // Entity types
 export type {
@@ -57,7 +57,7 @@ export type {
   Balance,
   DepositParams,
   WithdrawParams,
-} from './types';
+} from './types/index.js';
 
 // API types
 export type {
@@ -76,7 +76,7 @@ export type {
   PlaceOrderResponse,
   CancelOrderResponse,
   BuildTransactionResponse,
-} from './api';
+} from './api/index.js';
 
 // WebSocket types
 export type {
@@ -97,9 +97,9 @@ export type {
   WsErrorMessage,
   WsServerMessage,
   WsMessage,
-} from './api';
+} from './api/index.js';
 
-export { WS_CHANNELS } from './api';
+export { WS_CHANNELS } from './api/index.js';
 
 // Type guards and validators
 export {
@@ -124,10 +124,10 @@ export {
   assertTrade,
   assertOrderBook,
   assertBalance,
-} from './guards';
+} from './guards/index.js';
 
 // Client
-export type { ClientConfig, ResolvedConfig } from './client';
+export type { ClientConfig, ResolvedConfig } from './client/index.js';
 export {
   DEFAULT_BASE_URL,
   DEFAULT_WS_URL,
@@ -148,6 +148,6 @@ export {
   isRateLimitError,
   MatchbookClient,
   MatchbookWsClient,
-} from './client';
+} from './client/index.js';
 
-export type { BookCallback, TradeCallback, OrderCallback, ErrorCallback } from './client';
+export type { BookCallback, TradeCallback, OrderCallback, ErrorCallback } from './client/index.js';

--- a/ts-sdk/src/types/balance.ts
+++ b/ts-sdk/src/types/balance.ts
@@ -4,7 +4,7 @@
  * @module types/balance
  */
 
-import type { Quantity } from './primitives';
+import type { Quantity } from './primitives.js';
 
 /**
  * User balance for a specific market.

--- a/ts-sdk/src/types/book.ts
+++ b/ts-sdk/src/types/book.ts
@@ -4,7 +4,7 @@
  * @module types/book
  */
 
-import type { Price, Quantity } from './primitives';
+import type { Price, Quantity } from './primitives.js';
 
 /**
  * Aggregated price level in the order book.

--- a/ts-sdk/src/types/index.ts
+++ b/ts-sdk/src/types/index.ts
@@ -12,7 +12,7 @@ export type {
   TimeInForce,
   OrderStatus,
   SelfTradeBehavior,
-} from './primitives';
+} from './primitives.js';
 
 export {
   SIDES,
@@ -20,14 +20,14 @@ export {
   TIME_IN_FORCE_VALUES,
   ORDER_STATUSES,
   SELF_TRADE_BEHAVIORS,
-} from './primitives';
+} from './primitives.js';
 
-export type { Market, MarketSummary } from './market';
+export type { Market, MarketSummary } from './market.js';
 
-export type { Order, PlaceOrderParams, CancelOrderParams } from './order';
+export type { Order, PlaceOrderParams, CancelOrderParams } from './order.js';
 
-export type { Trade, TradeFilter } from './trade';
+export type { Trade, TradeFilter } from './trade.js';
 
-export type { BookLevel, OrderBook, BookChange, OrderBookUpdate } from './book';
+export type { BookLevel, OrderBook, BookChange, OrderBookUpdate } from './book.js';
 
-export type { Balance, DepositParams, WithdrawParams } from './balance';
+export type { Balance, DepositParams, WithdrawParams } from './balance.js';

--- a/ts-sdk/src/types/market.ts
+++ b/ts-sdk/src/types/market.ts
@@ -4,7 +4,7 @@
  * @module types/market
  */
 
-import type { Price, Quantity } from './primitives';
+import type { Price, Quantity } from './primitives.js';
 
 /**
  * Market configuration and state.

--- a/ts-sdk/src/types/order.ts
+++ b/ts-sdk/src/types/order.ts
@@ -4,7 +4,7 @@
  * @module types/order
  */
 
-import type { Price, Quantity, Side, OrderType, OrderStatus, TimeInForce, SelfTradeBehavior } from './primitives';
+import type { Price, Quantity, Side, OrderType, OrderStatus, TimeInForce, SelfTradeBehavior } from './primitives.js';
 
 /**
  * Order details.

--- a/ts-sdk/src/types/trade.ts
+++ b/ts-sdk/src/types/trade.ts
@@ -4,7 +4,7 @@
  * @module types/trade
  */
 
-import type { Price, Quantity, Side } from './primitives';
+import type { Price, Quantity, Side } from './primitives.js';
 
 /**
  * Executed trade record.

--- a/ts-sdk/tsconfig.cjs.json
+++ b/ts-sdk/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "CommonJS",
+    "moduleResolution": "bundler",
     "outDir": "./dist/cjs",
     "declaration": false,
     "declarationMap": false

--- a/ts-sdk/tsconfig.esm.json
+++ b/ts-sdk/tsconfig.esm.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "ESNext",
+    "module": "NodeNext",
     "outDir": "./dist/esm",
     "declaration": false,
     "declarationMap": false

--- a/ts-sdk/tsconfig.json
+++ b/ts-sdk/tsconfig.json
@@ -1,9 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "ESNext",
-    "moduleResolution": "node",
-    "ignoreDeprecations": "6.0",
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Part of #137.

## What

Migrates the ts-sdk build off `moduleResolution: "node"` (node10), which TypeScript 7 removes (`TS5108`). The resulting config compiles identically under TS 6 (current) and TS 7.0.2 (verified locally).

- **tsconfig.json**: `module`/`moduleResolution` → `NodeNext`, dropped `ignoreDeprecations: "6.0"`
- **tsconfig.esm.json**: `module` → `NodeNext` (emits ESM per package `"type": "module"`)
- **tsconfig.cjs.json**: keeps `module: CommonJS`, adds `moduleResolution: bundler` (nodenext resolution cannot pair with CommonJS emit — TS5110)
- **src**: explicit `.js` extensions on all relative imports (NodeNext requirement); directory imports now `./x/index.js`
- **package.json**:
  - `types` condition moved first in `exports` (conditions are order-sensitive; it was last, i.e. dead)
  - `build:cjs` now emits `dist/cjs/package.json` with `{"type":"commonjs"}` — without it Node treated `dist/cjs/*.js` as ESM under the package's `"type": "module"`, so `require()` of the CJS build was broken on Node < 22

## Why typescript is NOT bumped to 7 here

`typescript-eslint` (incl. all published alphas) pins peer `typescript >=4.8.4 <6.1.0`, and its `typescript-estree` hard-crashes at require time under TS7 (`ts.Extension` removed → `Cannot read properties of undefined (reading 'Cjs')`). npm `overrides` can rewrite the peer range but peers always resolve against the hoisted root copy, so there is no install-level workaround. The bump lands via dependabot once typescript-eslint ships TS7 support — after this PR it will be a green one-liner.

## Verification

- TS 6.0.3: `typecheck`, `lint`, `test` (60/60), `build` — all pass
- TS 7.0.2: all four tsconfigs compile clean (`tsc --noEmit` via `npx -p typescript@7.0.2`)
- End-to-end consumer against the `npm pack` tarball: ESM `import` OK, CJS `require` OK, consumer typecheck under `nodenext` resolves types via exports map